### PR TITLE
add endpoint parameter

### DIFF
--- a/flaskext/autoversion/__init__.py
+++ b/flaskext/autoversion/__init__.py
@@ -18,7 +18,7 @@ class Autoversion(object):
 		app.jinja_env.globals.update(
 				static_autoversion=self.static_autoversion)
 
-	def static_autoversion(self, filename):
+	def static_autoversion(self, filename, endpoint='static'):
 		if ( hasattr(self.autoversion_app_context, 'autoversion') and 
 				self.autoversion_app_context.autoversion ):
 			fullpath = os.path.join(
@@ -29,6 +29,6 @@ class Autoversion(object):
 				timestamp = str(os.path.getmtime(fullpath))
 			except OSError:
 				return url_for('static', filename=filename)
-			return url_for('static', filename=filename, ts=timestamp)
+			return url_for(endpoint, filename=filename, ts=timestamp)
 		else:
-			return url_for('static', filename=filename)
+			return url_for(endpoint, filename=filename)

--- a/flaskext/autoversion/__init__.py
+++ b/flaskext/autoversion/__init__.py
@@ -28,7 +28,7 @@ class Autoversion(object):
 			try:
 				timestamp = str(os.path.getmtime(fullpath))
 			except OSError:
-				return url_for('static', filename=filename)
+				return url_for(endpoint, filename=filename)
 			return url_for(endpoint, filename=filename, ts=timestamp)
 		else:
 			return url_for(endpoint, filename=filename)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def fread(filepath):
 
 setup(
 	name='Flask-Autoversion',
-	version='0.2.0',
+	version='0.2.1',
 	url='http://github.com/bmcculley/flask-autoversion',
 	license='BSD',
 	author='bmcculley',


### PR DESCRIPTION
Flask blueprints may specify their own static folders, but the previous flask_autoversion function didn't allow referring to them. 
I propose to add `endpoint` as a parameter with 'static' being the default so its backward compatible. 

Usage in my code looks like this:
`<script src="{{ static_autoversion('confirm_delete_user.js', endpoint='settings.static') }}"></script>`